### PR TITLE
AI observability using OpenInference and Phoenix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ A powerful yet simple multi-agent system using LangChain and LangGraph. Define e
    # Edit .env with your API keys
    ```
 
-3. **Run the system**:
+3. **Run Phoenix (observability)**
+   ```bash
+   phoenix serve &
+   ```
+   View will be able to view traces at http://localhost:6006/
+   
+4. **Run the system**:
    ```bash
    # Interactive mode
    python main.py

--- a/main.py
+++ b/main.py
@@ -11,6 +11,11 @@ import asyncio
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Union
 from pathlib import Path
+from openinference.instrumentation.langchain import LangChainInstrumentor
+from phoenix.otel import register
+
+tracer_provider = register()
+LangChainInstrumentor().instrument(tracer_provider=tracer_provider)
 
 # Load environment variables
 from dotenv import load_dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,9 @@ python-dotenv>=1.0.0
 
 # For Arcade tools (optional)
 arcadepy>=1.0.0
+
+# Phoenix/OpenInference Observability
+arize-phoenix>=11.31.0
+openinference-instrumentation-langchain>=0.1.51
+opentelemetry-sdk>=1.28.2
+opentelemetry-exporter-otlp>=1.36.0


### PR DESCRIPTION
Adds basic [OpenInference](https://github.com/Arize-ai/openinference) OTel tracing, using locally running [Phoenix](https://github.com/Arize-ai/phoenix) as the observability backend.

Note:
The code assumes you are using Phoenix as your backend (you could actually send the traces to any OTel-compliant backend). Also, the expectation is that Phoenix (or whatever backend you like) is already running (as in the README).

Alternatively:
For demos and workshops it might be simpler just to start Phoenix from within the app at start up, as in:
```python
import phoenix as px
session = px.launch_app()  # for file-based persistence, pass use_temp_dir=False
```

